### PR TITLE
fix: Use Foundry with London evm version

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,5 +5,6 @@ libs = ["lib"]
 solc = "0.8.25"
 optimizer = true
 optimizer_runs = 200
+evm_version = "London"
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options


### PR DESCRIPTION
This pull request includes a small update to the `foundry.toml` configuration file. The change specifies the EVM version to be used.

Configuration update:

* [`foundry.toml`](diffhunk://#diff-bac743fe3d899998e32393af53af8cc7d28c89c3d7fabfa48b01361cf8d42d9bR8): Added `evm_version = "London"` to specify the EVM version.